### PR TITLE
Changed namespaces to match file structure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "autoload": {
         "psr-0": {
-            "jtgrimes\\Less4laravel": "src/"
+            "Jtgrimes\\Less4laravel": "src/"
         }
     },
     "minimum-stability": "dev"

--- a/src/Jtgrimes/Less4laravel/Less.php
+++ b/src/Jtgrimes/Less4laravel/Less.php
@@ -1,4 +1,4 @@
-<?php namespace jtgrimes\Less4laravel;
+<?php namespace Jtgrimes\Less4laravel;
 
 use lessc;
 use Illuminate\Support\Facades\App;

--- a/src/Jtgrimes/Less4laravel/LessFacade.php
+++ b/src/Jtgrimes/Less4laravel/LessFacade.php
@@ -1,4 +1,4 @@
-<?php namespace jtgrimes\Less4laravel;
+<?php namespace Jtgrimes\Less4laravel;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/src/Jtgrimes/Less4laravel/LessServiceProvider.php
+++ b/src/Jtgrimes/Less4laravel/LessServiceProvider.php
@@ -1,4 +1,4 @@
-<?php namespace jtgrimes\Less4laravel;
+<?php namespace Jtgrimes\Less4laravel;
 
 use Illuminate\Support\ServiceProvider;
 


### PR DESCRIPTION
We had quite a few issues with file cases as the namespace didn't match the folder paths. The attached commit fixes all the problems that we encountered on multiple case sensitive filesystems 
